### PR TITLE
Add MSTest project for ProjectGraph cycle check

### DIFF
--- a/ProjectManagement.Tests/GraphTests.cs
+++ b/ProjectManagement.Tests/GraphTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProjectManagement.Core;
 
+using System;
+
 namespace ProjectManagement.Tests;
 
 [TestClass]

--- a/ProjectManagement.Tests/GraphTests.cs
+++ b/ProjectManagement.Tests/GraphTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProjectManagement.Core;
+
+namespace ProjectManagement.Tests;
+
+[TestClass]
+public class GraphTests
+{
+    [TestMethod]
+    public void AddingReverseDependencyCreatesCycle()
+    {
+        var graph = new ProjectGraph();
+        graph.AddTask("A", "Task A");
+        graph.AddTask("B", "Task B");
+        graph.AddDependency("A", "B");
+
+        Assert.ThrowsException<InvalidOperationException>(() => graph.AddDependency("B", "A"));
+    }
+}

--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectManagement\ProjectManagement.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ProjectManagement.sln
+++ b/ProjectManagement.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36119.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectManagement", "ProjectManagement\ProjectManagement.csproj", "{BACA1376-E388-9F87-865D-371ED350B1D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectManagement.Tests", "ProjectManagement.Tests\ProjectManagement.Tests.csproj", "{E135BB0A-9335-468E-A1BE-EFAFAAF3C114}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
@@ -19,8 +21,12 @@ Global
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BACA1376-E388-9F87-865D-371ED350B1D3}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {BACA1376-E388-9F87-865D-371ED350B1D3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/ProjectManagement.sln
+++ b/ProjectManagement.sln
@@ -21,12 +21,11 @@ Global
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BACA1376-E388-9F87-865D-371ED350B1D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {BACA1376-E388-9F87-865D-371ED350B1D3}.Release|Any CPU.Build.0 = Release|Any CPU
-                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.Build.0 = Release|Any CPU
-        EndGlobalSection
+		{E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E135BB0A-9335-468E-A1BE-EFAFAAF3C114}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- create `ProjectManagement.Tests` MSTest project
- test that adding reverse dependency throws `InvalidOperationException`
- connect new test project to `ProjectManagement.sln`

## Testing
- `dotnet test ProjectManagement.Tests/ProjectManagement.Tests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445c5b8f1c832a813af59b424f8821