### PR TITLE
Add Coverlet coverage workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,8 +29,6 @@ jobs:
         /p:CollectCoverage=true
         /p:CoverletOutput=TestResults/coverage/
         /p:CoverletOutputFormat=cobertura
-        /p:Threshold=90
-        /p:ThresholdType=line
     - name: Generate coverage report
       run: >-
         reportgenerator -reports:TestResults/coverage/coverage.cobertura.xml
@@ -50,4 +48,11 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         path: coveragereport/Summary.md
+    - name: Enforce minimum coverage
+      if: always()
+      run: |
+        line_rate=$(grep -o 'line-rate="[0-9.]*"' TestResults/coverage/coverage.cobertura.xml | head -n1 | cut -d'"' -f2)
+        coverage=$(awk "BEGIN {print ${line_rate}*100}")
+        echo "Line coverage: ${coverage}%"
+        awk -v cov=${coverage} 'BEGIN { if (cov < 90) exit 1 }'
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,6 @@ jobs:
       run: dotnet build --no-restore ProjectManagement.sln
     - name: Test with coverage
       run: |
-        mkdir -p TestResults/coverage
         dotnet test ProjectManagement.sln --no-build --logger "trx;LogFileName=testresults.trx" \
           --results-directory TestResults \
           /p:CollectCoverage=true \
@@ -32,7 +31,7 @@ jobs:
           /p:CoverletOutputFormat=cobertura
     - name: Generate coverage report
       run: >-
-        ~/.dotnet/tools/reportgenerator -reports:TestResults/coverage/coverage.cobertura.xml
+        ~/.dotnet/tools/reportgenerator -reports:ProjectManagement.Tests/TestResults/coverage/coverage.cobertura.xml
         -targetdir:coveragereport -reporttypes:Html;MarkdownSummary
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4
@@ -52,7 +51,7 @@ jobs:
     - name: Enforce minimum coverage
       if: always()
       run: |
-        line_rate=$(grep -o 'line-rate="[0-9.]*"' TestResults/coverage/coverage.cobertura.xml | head -n1 | cut -d'"' -f2)
+        line_rate=$(grep -o 'line-rate="[0-9.]*"' ProjectManagement.Tests/TestResults/coverage/coverage.cobertura.xml | head -n1 | cut -d'"' -f2)
         coverage=$(awk "BEGIN {print ${line_rate}*100}")
         echo "Line coverage: ${coverage}%"
         awk -v cov=${coverage} 'BEGIN { if (cov < 90) exit 1 }'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,15 +23,16 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ProjectManagement.sln
     - name: Test with coverage
-      run: >-
-        dotnet test ProjectManagement.sln --no-build --logger trx
-        --results-directory TestResults
-        /p:CollectCoverage=true
-        /p:CoverletOutput=TestResults/coverage/
-        /p:CoverletOutputFormat=cobertura
+      run: |
+        mkdir -p TestResults/coverage
+        dotnet test ProjectManagement.sln --no-build --logger "trx;LogFileName=testresults.trx" \
+          --results-directory TestResults \
+          /p:CollectCoverage=true \
+          /p:CoverletOutput=TestResults/coverage/ \
+          /p:CoverletOutputFormat=cobertura
     - name: Generate coverage report
       run: >-
-        reportgenerator -reports:TestResults/coverage/coverage.cobertura.xml
+        ~/.dotnet/tools/reportgenerator -reports:TestResults/coverage/coverage.cobertura.xml
         -targetdir:coveragereport -reporttypes:Html;MarkdownSummary
     - name: Upload coverage artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,9 +16,38 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '9.0.x'
+    - name: Install report generator
+      run: dotnet tool install --global dotnet-reportgenerator-globaltool
     - name: Restore dependencies
       run: dotnet restore ProjectManagement.sln
     - name: Build
       run: dotnet build --no-restore ProjectManagement.sln
-    - name: Test
-      run: dotnet test --no-build ProjectManagement.sln
+    - name: Test with coverage
+      run: >-
+        dotnet test ProjectManagement.sln --no-build --logger trx
+        --results-directory TestResults
+        /p:CollectCoverage=true
+        /p:CoverletOutput=TestResults/coverage/
+        /p:CoverletOutputFormat=cobertura
+        /p:Threshold=90
+        /p:ThresholdType=line
+    - name: Generate coverage report
+      run: >-
+        reportgenerator -reports:TestResults/coverage/coverage.cobertura.xml
+        -targetdir:coveragereport -reporttypes:Html;MarkdownSummary
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coveragereport
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: TestResults
+    - name: Coverage PR comment
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        path: coveragereport/Summary.md
+

--- a/ProjectManagement.Tests/ProjectManagement.Tests.csproj
+++ b/ProjectManagement.Tests/ProjectManagement.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add coverlet.msbuild to test project
- run dotnet tests with coverage in CI
- generate coverage report and comment summary on PR

## Testing
- `dotnet test ProjectManagement.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684466fce70c832ab0bc2b3a6eba5883